### PR TITLE
Require explicit JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/rakium_be?schema=public"
+JWT_SECRET="replace-with-a-long-random-secret"
+JWT_EXPIRATION="7d"
+PORT=3000
+CORS_ORIGINS="http://localhost:4200,http://localhost:5173,http://localhost:3000"
+
+# Optional: Backblaze B2 uploads
+BACKBLAZE_ACCESS_KEY_ID=""
+BACKBLAZE_SECRET_ACCESS_KEY=""
+BACKBLAZE_BUCKET_NAME=""

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,18 +1,26 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { UsersModule } from '../users/users.module';
+import { getRequiredEnv } from '../config/required-env';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'your-secret-key',
-      signOptions: { expiresIn: '1d' },
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: getRequiredEnv('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRATION') || '1d',
+        },
+      }),
     }),
   ],
   controllers: [AuthController],

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { getRequiredEnv } from '../config/required-env';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -8,7 +9,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'your-secret-key',
+      secretOrKey: getRequiredEnv('JWT_SECRET'),
     });
   }
 

--- a/src/config/required-env.ts
+++ b/src/config/required-env.ts
@@ -1,0 +1,10 @@
+export function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value || value.trim() === '') {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+


### PR DESCRIPTION
## Summary
- remove the insecure JWT fallback secret
- fail fast when required environment variables are missing
- add a local .env.example for required runtime config

## Verification
- npm.cmd run build
- confirmed /api responds 200 locally
- confirmed seed admin login works locally
- confirmed missing JWT_SECRET reports: Missing required environment variable: JWT_SECRET