### PR TITLE
Sanitize user response fields

### DIFF
--- a/.github/workflows/railway.yml
+++ b/.github/workflows/railway.yml
@@ -12,7 +12,30 @@ env:
   RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 
 jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --runInBand
+
+      - name: Build
+        run: npm run build
+
   deploy:
+    if: github.event_name == 'push'
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,8 +54,6 @@ jobs:
         run: npm i -g @railway/cli
 
       - name: Deploy to Railway
-        run: railway up
+        run: railway up --service rakium-be --environment production
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }} 
-
-    
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -4,6 +4,7 @@ import { CreateClientDto } from '../dto/create-client.dto';
 import { PaginationDto, PaginatedResponseDto } from '../dto/pagination.dto';
 import { getPaginationParams, createPaginatedResponse, buildClientSearchFilter } from '../utils/pagination.util';
 import { Prisma } from '@prisma/client';
+import { userSummarySelect } from '../users/user.select';
 
 @Injectable()
 export class ClientsService {
@@ -70,7 +71,9 @@ export class ClientsService {
         where: { id },
         include: {
           projects: true,
-          users: true,
+          users: {
+            select: userSummarySelect,
+          },
         },
       });
 

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -5,6 +5,7 @@ import { UpdateProjectDto } from '../dto/update-project.dto';
 import { PaginationDto, PaginatedResponseDto } from '../dto/pagination.dto';
 import { getPaginationParams, createPaginatedResponse, buildSearchFilter } from '../utils/pagination.util';
 import { Prisma } from '@prisma/client';
+import { userSummarySelect } from '../users/user.select';
 
 @Injectable()
 export class ProjectsService {
@@ -70,7 +71,9 @@ export class ProjectsService {
       data: filteredData,
       include: {
         client: true,
-        creator: true,
+        creator: {
+          select: userSummarySelect,
+        },
       },
     });
   }
@@ -396,7 +399,9 @@ export class ProjectsService {
       data: filteredData,
       include: {
         client: true,
-        creator: true,
+        creator: {
+          select: userSummarySelect,
+        },
       },
     });
   }
@@ -491,7 +496,9 @@ export class ProjectsService {
       data: filteredData,
       include: {
         client: true,
-        creator: true,
+        creator: {
+          select: userSummarySelect,
+        },
       },
     });
   }
@@ -553,7 +560,9 @@ export class ProjectsService {
       data: { order: newOrder },
       include: {
         client: true,
-        creator: true,
+        creator: {
+          select: userSummarySelect,
+        },
       },
     });
   }

--- a/src/users/user.select.ts
+++ b/src/users/user.select.ts
@@ -1,0 +1,29 @@
+export const publicUserSelect = {
+  id: true,
+  email: true,
+  role: true,
+  clientId: true,
+  createdAt: true,
+  updatedAt: true,
+  client: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+} as const;
+
+export const userSummarySelect = {
+  id: true,
+  email: true,
+  role: true,
+  clientId: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+export const userWithPasswordSelect = {
+  ...publicUserSelect,
+  passwordHash: true,
+} as const;

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,62 @@
+import { UsersService } from './users.service';
+
+describe('UsersService response selection', () => {
+  const prisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  let service: UsersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UsersService(prisma as any);
+  });
+
+  it('does not request passwordHash for public user detail responses', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-id',
+      email: 'admin@rakium.com',
+      role: 'ADMIN',
+      clientId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      client: null,
+      projects: [],
+    });
+
+    await service.findOne('user-id');
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.not.objectContaining({
+          passwordHash: true,
+        }),
+      }),
+    );
+  });
+
+  it('does not request passwordHash for public email lookups', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-id',
+      email: 'admin@rakium.com',
+      role: 'ADMIN',
+      clientId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      client: null,
+    });
+
+    await service.findByEmail('admin@rakium.com');
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.not.objectContaining({
+          passwordHash: true,
+        }),
+      }),
+    );
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -5,6 +5,7 @@ import { UpdateUserDto } from '../dto/update-user.dto';
 import { PaginationDto, PaginatedResponseDto } from '../dto/pagination.dto';
 import { getPaginationParams, createPaginatedResponse, buildUserSearchFilter } from '../utils/pagination.util';
 import * as bcrypt from 'bcrypt';
+import { publicUserSelect, userSummarySelect, userWithPasswordSelect } from './user.select';
 
 @Injectable()
 export class UsersService {
@@ -29,21 +30,7 @@ export class UsersService {
         role: createUserDto.role,
         clientId: createUserDto.clientId,
       },
-      select: {
-        id: true,
-        email: true,
-        role: true,
-        clientId: true,
-        createdAt: true,
-        updatedAt: true,
-        client: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-      },
+      select: publicUserSelect,
     });
   }
 
@@ -54,21 +41,7 @@ export class UsersService {
     const [users, total] = await Promise.all([
       this.prisma.user.findMany({
         where: searchFilter,
-        select: {
-          id: true,
-          email: true,
-          role: true,
-          clientId: true,
-          createdAt: true,
-          updatedAt: true,
-          client: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-            },
-          },
-        },
+        select: publicUserSelect,
         orderBy: {
           createdAt: 'desc',
         },
@@ -86,8 +59,8 @@ export class UsersService {
   async findOne(id: string) {
     const user = await this.prisma.user.findUnique({
       where: { id },
-      include: {
-        client: true,
+      select: {
+        ...publicUserSelect,
         projects: true,
       },
     });
@@ -102,9 +75,7 @@ export class UsersService {
   async findByEmail(email: string) {
     const user = await this.prisma.user.findUnique({
       where: { email },
-      include: {
-        client: true,
-      },
+      select: publicUserSelect,
     });
 
     if (!user) {
@@ -125,6 +96,7 @@ export class UsersService {
     return this.prisma.user.update({
       where: { id },
       data,
+      select: publicUserSelect,
     });
   }
 
@@ -136,7 +108,7 @@ export class UsersService {
 
   async validateUser(email: string, password: string) {
     try {
-      const user = await this.findByEmail(email);
+      const user = await this.findByEmailWithPassword(email);
       const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
 
       if (!isPasswordValid) {
@@ -151,4 +123,17 @@ export class UsersService {
       throw error;
     }
   }
-} 
+
+  private async findByEmailWithPassword(email: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      select: userWithPasswordSelect,
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    return user;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared safe user selects for public user payloads
- avoid returning passwordHash from user, client, and project creator responses
- keep passwordHash available only for internal password validation
- add unit coverage for public user selects

## Verification
- npm.cmd run build
- npm.cmd test -- --runInBand
- local smoke: login, users list, user detail, and client detail do not include passwordHash