### PR TITLE
Introduce storage provider abstraction

### DIFF
--- a/src/upload/storage/backblaze-storage.provider.ts
+++ b/src/upload/storage/backblaze-storage.provider.ts
@@ -1,0 +1,113 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import {
+  PresignedUploadUrlInput,
+  StorageProvider,
+  UploadObjectInput,
+} from './storage-provider.interface';
+
+@Injectable()
+export class BackblazeStorageProvider implements StorageProvider {
+  readonly providerName = 'backblaze';
+
+  private readonly s3Client?: S3Client;
+  private readonly bucketName?: string;
+  private readonly accessKeyId?: string;
+  private readonly secretAccessKey?: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.bucketName = this.configService.get<string>('BACKBLAZE_BUCKET_NAME');
+    this.accessKeyId = this.configService.get<string>('BACKBLAZE_ACCESS_KEY_ID');
+    this.secretAccessKey = this.configService.get<string>('BACKBLAZE_SECRET_ACCESS_KEY');
+
+    if (!this.accessKeyId || !this.secretAccessKey || !this.bucketName) {
+      return;
+    }
+
+    this.s3Client = new S3Client({
+      region: 'us-east-005',
+      endpoint: 'https://s3.us-east-005.backblazeb2.com',
+      credentials: {
+        accessKeyId: this.accessKeyId,
+        secretAccessKey: this.secretAccessKey,
+      },
+      forcePathStyle: true,
+    });
+  }
+
+  assertConfigured(): void {
+    if (!this.s3Client || !this.accessKeyId || !this.secretAccessKey || !this.bucketName) {
+      throw new BadRequestException(
+        'Backblaze B2 no está configurado. Verifica las variables de entorno BACKBLAZE_ACCESS_KEY_ID, BACKBLAZE_SECRET_ACCESS_KEY y BACKBLAZE_BUCKET_NAME',
+      );
+    }
+  }
+
+  async uploadObject(input: UploadObjectInput): Promise<string> {
+    this.assertConfigured();
+
+    try {
+      const command = new PutObjectCommand({
+        Bucket: this.bucketName,
+        Key: input.key,
+        Body: input.body,
+        ContentType: input.contentType,
+        ACL: input.acl ?? 'public-read',
+      });
+
+      await this.s3Client.send(command);
+
+      return `https://${this.bucketName}.s3.us-east-005.backblazeb2.com/${input.key}`;
+    } catch (error) {
+      this.handleStorageError(error, 'Error al subir el archivo');
+    }
+  }
+
+  async deleteObjectByUrl(fileUrl: string): Promise<void> {
+    this.assertConfigured();
+
+    try {
+      const urlParts = fileUrl.split('/');
+      const fileName = urlParts.slice(-2).join('/');
+
+      const command = new DeleteObjectCommand({
+        Bucket: this.bucketName,
+        Key: fileName,
+      });
+
+      await this.s3Client.send(command);
+    } catch (error) {
+      this.handleStorageError(error, 'Error al eliminar el archivo');
+    }
+  }
+
+  async createPresignedUploadUrl(input: PresignedUploadUrlInput): Promise<string> {
+    this.assertConfigured();
+
+    const command = new PutObjectCommand({
+      Bucket: this.bucketName,
+      Key: input.key,
+      ContentType: input.contentType,
+    });
+
+    return getSignedUrl(this.s3Client, command, { expiresIn: input.expiresIn ?? 3600 });
+  }
+
+  private handleStorageError(error: unknown, defaultMessage: string): never {
+    const storageError = error as { name?: string; message?: string };
+
+    if (storageError.name === 'InvalidAccessKeyId') {
+      throw new BadRequestException(
+        'Credenciales de Backblaze B2 inválidas. Verifica BACKBLAZE_ACCESS_KEY_ID y BACKBLAZE_SECRET_ACCESS_KEY',
+      );
+    }
+
+    if (storageError.name === 'NoSuchBucket') {
+      throw new BadRequestException('Bucket de Backblaze B2 no encontrado. Verifica BACKBLAZE_BUCKET_NAME');
+    }
+
+    throw new BadRequestException(`${defaultMessage}: ${storageError.message ?? 'error desconocido'}`);
+  }
+}

--- a/src/upload/storage/storage-provider.interface.ts
+++ b/src/upload/storage/storage-provider.interface.ts
@@ -1,0 +1,23 @@
+export const STORAGE_PROVIDER = Symbol('STORAGE_PROVIDER');
+
+export interface UploadObjectInput {
+  key: string;
+  body: Buffer;
+  contentType: string;
+  acl?: 'public-read' | 'private';
+}
+
+export interface PresignedUploadUrlInput {
+  key: string;
+  contentType: string;
+  expiresIn?: number;
+}
+
+export interface StorageProvider {
+  readonly providerName: string;
+
+  assertConfigured(): void;
+  uploadObject(input: UploadObjectInput): Promise<string>;
+  deleteObjectByUrl(fileUrl: string): Promise<void>;
+  createPresignedUploadUrl(input: PresignedUploadUrlInput): Promise<string>;
+}

--- a/src/upload/upload.module.ts
+++ b/src/upload/upload.module.ts
@@ -3,11 +3,21 @@ import { UploadService } from './upload.service';
 import { UploadController } from './upload.controller';
 import { ConfigModule } from '@nestjs/config';
 import { ImageOptimizerService } from './image-optimizer.service';
+import { BackblazeStorageProvider } from './storage/backblaze-storage.provider';
+import { STORAGE_PROVIDER } from './storage/storage-provider.interface';
 
 @Module({
   imports: [ConfigModule],
   controllers: [UploadController],
-  providers: [UploadService, ImageOptimizerService],
+  providers: [
+    UploadService,
+    ImageOptimizerService,
+    BackblazeStorageProvider,
+    {
+      provide: STORAGE_PROVIDER,
+      useExisting: BackblazeStorageProvider,
+    },
+  ],
   exports: [UploadService, ImageOptimizerService],
 })
-export class UploadModule {} 
+export class UploadModule {}

--- a/src/upload/upload.service.spec.ts
+++ b/src/upload/upload.service.spec.ts
@@ -1,0 +1,78 @@
+import { BadRequestException } from '@nestjs/common';
+import { UploadService } from './upload.service';
+import { StorageProvider } from './storage/storage-provider.interface';
+
+describe('UploadService storage provider integration', () => {
+  const imageOptimizer = {
+    needsOptimization: jest.fn(),
+    autoOptimize: jest.fn(),
+    createImageVariants: jest.fn(),
+  };
+
+  const prisma = {
+    project: {
+      findUnique: jest.fn(),
+    },
+    gallery: {
+      create: jest.fn(),
+    },
+  };
+
+  const storageProvider: jest.Mocked<StorageProvider> = {
+    providerName: 'test-storage',
+    assertConfigured: jest.fn(),
+    uploadObject: jest.fn(),
+    deleteObjectByUrl: jest.fn(),
+    createPresignedUploadUrl: jest.fn(),
+  };
+
+  let service: UploadService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UploadService(imageOptimizer as any, prisma as any, storageProvider);
+    imageOptimizer.needsOptimization.mockResolvedValue(false);
+    storageProvider.uploadObject.mockResolvedValue('https://cdn.example.com/images/file.jpg');
+  });
+
+  it('uploads validated files through the configured storage provider', async () => {
+    const file = createFile({ mimetype: 'image/jpeg', originalname: 'photo.jpg' });
+
+    const url = await service.uploadFile(file, 'projects/demo', false);
+
+    expect(url).toBe('https://cdn.example.com/images/file.jpg');
+    expect(storageProvider.assertConfigured).toHaveBeenCalledTimes(1);
+    expect(storageProvider.uploadObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.stringMatching(/^projects\/demo\/\d+-[a-z0-9]+\.jpg$/),
+        body: file.buffer,
+        contentType: 'image/jpeg',
+        acl: 'public-read',
+      }),
+    );
+  });
+
+  it('rejects unsupported file types before calling the provider upload', async () => {
+    const file = createFile({ mimetype: 'application/pdf', originalname: 'doc.pdf' });
+
+    await expect(service.uploadFile(file)).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(storageProvider.uploadObject).not.toHaveBeenCalled();
+  });
+
+  function createFile(overrides: Partial<Express.Multer.File>): Express.Multer.File {
+    return {
+      fieldname: 'file',
+      originalname: 'photo.jpg',
+      encoding: '7bit',
+      mimetype: 'image/jpeg',
+      size: 1024,
+      buffer: Buffer.from('image'),
+      destination: '',
+      filename: '',
+      path: '',
+      stream: null as any,
+      ...overrides,
+    };
+  }
+});

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -1,51 +1,22 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { ConfigService } from '@nestjs/config';
+import { Inject, Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ImageOptimizerService } from './image-optimizer.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { STORAGE_PROVIDER, StorageProvider } from './storage/storage-provider.interface';
 
 @Injectable()
 export class UploadService {
-  private s3Client: S3Client;
-  private bucketName: string;
-  private accessKeyId: string;
-  private secretAccessKey: string;
-
   constructor(
-    private configService: ConfigService,
     private imageOptimizer: ImageOptimizerService,
-    private prisma: PrismaService
-  ) {
-    this.bucketName = this.configService.get<string>('BACKBLAZE_BUCKET_NAME');
-    this.accessKeyId = this.configService.get<string>('BACKBLAZE_ACCESS_KEY_ID');
-    this.secretAccessKey = this.configService.get<string>('BACKBLAZE_SECRET_ACCESS_KEY');
-    
-    if (!this.accessKeyId || !this.secretAccessKey || !this.bucketName) {
-      return;
-    }
-    
-    // Configurar cliente S3 para Backblaze B2
-    this.s3Client = new S3Client({
-      region: 'us-east-005',
-      endpoint: 'https://s3.us-east-005.backblazeb2.com',
-      credentials: {
-        accessKeyId: this.accessKeyId,
-        secretAccessKey: this.secretAccessKey,
-      },
-      forcePathStyle: true,
-    });
-  }
+    private prisma: PrismaService,
+    @Inject(STORAGE_PROVIDER) private storageProvider: StorageProvider,
+  ) {}
 
   async uploadFile(file: Express.Multer.File, folder: string = 'images', optimize: boolean = true): Promise<string> {
     if (!file) {
       throw new BadRequestException('No se proporcionó ningún archivo');
     }
 
-    // Verificar que Backblaze esté configurado
-    if (!this.accessKeyId || !this.secretAccessKey || !this.bucketName) {
-      throw new BadRequestException('Backblaze B2 no está configurado. Verifica las variables de entorno BACKBLAZE_ACCESS_KEY_ID, BACKBLAZE_SECRET_ACCESS_KEY y BACKBLAZE_BUCKET_NAME');
-    }
+    this.storageProvider.assertConfigured();
 
     // Validar tipo de archivo
     const allowedMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
@@ -76,30 +47,12 @@ export class UploadService {
     const randomString = Math.random().toString(36).substring(2, 15);
     const fileName = `${folder}/${timestamp}-${randomString}.${fileExtension}`;
 
-    try {
-      const command = new PutObjectCommand({
-        Bucket: this.bucketName,
-        Key: fileName,
-        Body: uploadBuffer,
-        ContentType: uploadMimeType,
-        ACL: 'public-read',
-      });
-
-      await this.s3Client.send(command);
-
-      // Retornar la URL pública del archivo
-      return `https://${this.bucketName}.s3.us-east-005.backblazeb2.com/${fileName}`;
-    } catch (error) {
-      if (error.name === 'InvalidAccessKeyId') {
-        throw new BadRequestException('Credenciales de Backblaze B2 inválidas. Verifica BACKBLAZE_ACCESS_KEY_ID y BACKBLAZE_SECRET_ACCESS_KEY');
-      }
-      
-      if (error.name === 'NoSuchBucket') {
-        throw new BadRequestException('Bucket de Backblaze B2 no encontrado. Verifica BACKBLAZE_BUCKET_NAME');
-      }
-      
-      throw new BadRequestException(`Error al subir el archivo: ${error.message}`);
-    }
+    return this.storageProvider.uploadObject({
+      key: fileName,
+      body: uploadBuffer,
+      contentType: uploadMimeType,
+      acl: 'public-read',
+    });
   }
 
   async uploadWithVariants(
@@ -129,16 +82,12 @@ export class UploadService {
       const fileName = `${folder}/${variantName}/${timestamp}-${randomString}.${fileExtension}`;
 
       try {
-        const command = new PutObjectCommand({
-          Bucket: this.bucketName,
-          Key: fileName,
-          Body: variant.buffer,
-          ContentType: variant.mimeType,
-          ACL: 'public-read',
+        urls[variantName] = await this.storageProvider.uploadObject({
+          key: fileName,
+          body: variant.buffer,
+          contentType: variant.mimeType,
+          acl: 'public-read',
         });
-
-        await this.s3Client.send(command);
-        urls[variantName] = `https://${this.bucketName}.s3.us-east-005.backblazeb2.com/${fileName}`;
       } catch (error) {
         throw new BadRequestException(`Error al subir la variante ${variantName}: ${error.message}`);
       }
@@ -148,38 +97,15 @@ export class UploadService {
   }
 
   async deleteFile(fileUrl: string): Promise<void> {
-    if (!this.s3Client || !this.bucketName) {
-      throw new BadRequestException('Backblaze B2 no está configurado');
-    }
-
-    try {
-      // Extraer la clave del archivo de la URL
-      const urlParts = fileUrl.split('/');
-      const fileName = urlParts.slice(-2).join('/'); // Obtener folder/filename
-
-      const command = new DeleteObjectCommand({
-        Bucket: this.bucketName,
-        Key: fileName,
-      });
-
-      await this.s3Client.send(command);
-    } catch (error) {
-      throw new BadRequestException(`Error al eliminar el archivo: ${error.message}`);
-    }
+    await this.storageProvider.deleteObjectByUrl(fileUrl);
   }
 
   async generatePresignedUrl(fileName: string, contentType: string, expiresIn: number = 3600): Promise<string> {
-    if (!this.s3Client || !this.bucketName) {
-      throw new BadRequestException('Backblaze B2 no está configurado');
-    }
-
-    const command = new PutObjectCommand({
-      Bucket: this.bucketName,
-      Key: fileName,
-      ContentType: contentType,
+    return this.storageProvider.createPresignedUploadUrl({
+      key: fileName,
+      contentType,
+      expiresIn,
     });
-
-    return await getSignedUrl(this.s3Client, command, { expiresIn });
   }
 
   async uploadImage(file: Express.Multer.File, projectId: string, order?: number) {
@@ -210,4 +136,4 @@ export class UploadService {
 
     return galleryItem;
   }
-} 
+}


### PR DESCRIPTION
## Summary
- introduce a `StorageProvider` interface and injection token
- move current Backblaze B2/S3-specific upload, delete and presigned URL logic into `BackblazeStorageProvider`
- keep `UploadService` focused on validation, image optimization and gallery persistence
- add unit coverage for upload validation and provider delegation

## Validation
- npm.cmd test -- --runInBand
- npm.cmd run build
- git diff --check

## Notes
- This PR does not switch storage providers yet.
- Backblaze remains the active provider, so runtime behavior should stay the same while making the next GCS PR smaller.