### PR TITLE
Add Backblaze to GCS migration plan

### DIFF
--- a/STORAGE_MIGRATION_BACKBLAZE_TO_GCS.md
+++ b/STORAGE_MIGRATION_BACKBLAZE_TO_GCS.md
@@ -1,0 +1,125 @@
+# Backblaze to Google Cloud Storage Migration
+
+This runbook prepares and executes the object migration without changing production traffic by default.
+
+## Safety rules
+
+- Do not run the cutover without explicit approval.
+- Do not commit dumps, manifests with sensitive URLs, service account JSON, or bucket credentials.
+- Keep `STORAGE_PROVIDER=backblaze` or unset until upload and read checks pass against GCS.
+- Rotate any credential that was previously committed or shared in docs.
+
+## Required inputs
+
+- Current Backblaze env:
+  - `BACKBLAZE_BUCKET_NAME`
+  - `BACKBLAZE_ACCESS_KEY_ID`
+  - `BACKBLAZE_SECRET_ACCESS_KEY`
+- Target GCS env:
+  - `GCS_BUCKET_NAME`
+  - `GCS_PROJECT_ID`
+  - `GCS_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS`
+- Database env:
+  - `DATABASE_URL`
+
+## 1. Generate the migration manifest
+
+The manifest inventories object URLs referenced by the database and maps each Backblaze object key to the expected GCS public URL.
+
+```bash
+GCS_BUCKET_NAME="target-gcs-bucket" \
+BACKBLAZE_BUCKET_NAME="source-backblaze-bucket" \
+DATABASE_URL="postgresql://user:password@host:5432/db?schema=public" \
+npm run storage:plan-gcs-migration
+```
+
+Default output:
+
+```text
+.tmp/storage-migration/backblaze-to-gcs-manifest.json
+```
+
+Review:
+
+- `assets.length` is the number of DB references ready to migrate.
+- `skippedUrls` should be empty or understood before copying.
+- `objectKey` values should match the paths in Backblaze.
+- `targetUrl` should use the expected GCS bucket.
+
+## 2. Copy objects
+
+Recommended options:
+
+- Use Google Cloud Storage Transfer Service from Backblaze S3-compatible source to GCS.
+- Or use `rclone` configured with Backblaze B2/S3 and GCS remotes.
+
+Example with `rclone`:
+
+```bash
+rclone copy backblaze:source-backblaze-bucket gcs:target-gcs-bucket \
+  --fast-list \
+  --checksum \
+  --transfers 8 \
+  --checkers 16 \
+  --log-file .tmp/storage-migration/rclone-copy.log \
+  --log-level INFO
+```
+
+Do not delete Backblaze objects during the first copy.
+
+## 3. Validate copy
+
+Use the manifest to sample-check:
+
+- A few gallery URLs.
+- A few project before/after image URLs.
+- At least one object per folder prefix.
+- Total object counts in source and target buckets.
+
+Suggested checks:
+
+```bash
+rclone check backblaze:source-backblaze-bucket gcs:target-gcs-bucket \
+  --one-way \
+  --log-file .tmp/storage-migration/rclone-check.log \
+  --log-level INFO
+```
+
+## 4. Application cutover
+
+Only after copy validation:
+
+1. Merge the GCS provider PR.
+2. Configure production env:
+   - `STORAGE_PROVIDER=gcs`
+   - `GCS_BUCKET_NAME`
+   - `GCS_PROJECT_ID`
+   - `GCS_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS`
+3. Deploy.
+4. Upload a new test image and confirm it lands in GCS.
+
+Existing database URLs still point to Backblaze until URL rewrite is done.
+
+## 5. URL rewrite plan
+
+After object copy is validated, create a separate PR or one-time migration script to update:
+
+- `Gallery.url`
+- `Project.imageBefore`
+- `Project.imageAfter`
+
+Use the generated manifest as the source of truth:
+
+- Replace each `currentUrl` with `targetUrl`.
+- Wrap updates in a transaction.
+- Take a database backup first.
+- Keep Backblaze objects for rollback until the frontend has been verified against rewritten URLs.
+
+## 6. Rollback
+
+If GCS upload/read checks fail:
+
+1. Set `STORAGE_PROVIDER=backblaze` or remove `STORAGE_PROVIDER`.
+2. Redeploy.
+3. Do not rewrite DB URLs.
+4. Keep Backblaze bucket unchanged until GCS is fully validated.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "seed": "ts-node prisma/seed.ts",
     "assign-lautarovulcano": "ts-node scripts/assign-lautarovulcano-client.ts",
+    "storage:plan-gcs-migration": "ts-node scripts/plan-backblaze-to-gcs-migration.ts",
     "db:migrate": "prisma migrate deploy",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",

--- a/scripts/plan-backblaze-to-gcs-migration.ts
+++ b/scripts/plan-backblaze-to-gcs-migration.ts
@@ -1,0 +1,182 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { PrismaClient } from '@prisma/client';
+
+type AssetSource = 'gallery.url' | 'project.imageBefore' | 'project.imageAfter';
+
+interface AssetReference {
+  source: AssetSource;
+  recordId: string;
+  projectId?: string;
+  currentUrl: string;
+  objectKey: string;
+  targetUrl: string;
+}
+
+interface MigrationManifest {
+  generatedAt: string;
+  sourceBucket?: string;
+  targetBucket: string;
+  assets: AssetReference[];
+  skippedUrls: Array<{
+    source: AssetSource;
+    recordId: string;
+    projectId?: string;
+    url: string;
+    reason: string;
+  }>;
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const targetBucket = getRequiredEnv('GCS_BUCKET_NAME');
+  const sourceBucket = process.env.BACKBLAZE_BUCKET_NAME;
+  const outputPath = resolve(process.env.STORAGE_MIGRATION_MANIFEST_PATH ?? '.tmp/storage-migration/backblaze-to-gcs-manifest.json');
+
+  const [galleryItems, projects] = await Promise.all([
+    prisma.gallery.findMany({
+      select: {
+        id: true,
+        projectId: true,
+        url: true,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    }),
+    prisma.project.findMany({
+      select: {
+        id: true,
+        imageBefore: true,
+        imageAfter: true,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    }),
+  ]);
+
+  const manifest: MigrationManifest = {
+    generatedAt: new Date().toISOString(),
+    sourceBucket,
+    targetBucket,
+    assets: [],
+    skippedUrls: [],
+  };
+
+  const seen = new Set<string>();
+
+  for (const item of galleryItems) {
+    addAsset(manifest, seen, {
+      source: 'gallery.url',
+      recordId: item.id,
+      projectId: item.projectId,
+      currentUrl: item.url,
+    });
+  }
+
+  for (const project of projects) {
+    if (project.imageBefore) {
+      addAsset(manifest, seen, {
+        source: 'project.imageBefore',
+        recordId: project.id,
+        projectId: project.id,
+        currentUrl: project.imageBefore,
+      });
+    }
+
+    if (project.imageAfter) {
+      addAsset(manifest, seen, {
+        source: 'project.imageAfter',
+        recordId: project.id,
+        projectId: project.id,
+        currentUrl: project.imageAfter,
+      });
+    }
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(`Storage migration manifest written to ${outputPath}`);
+  console.log(`Assets ready to migrate: ${manifest.assets.length}`);
+  console.log(`Skipped URLs: ${manifest.skippedUrls.length}`);
+}
+
+function addAsset(
+  manifest: MigrationManifest,
+  seen: Set<string>,
+  input: Omit<AssetReference, 'objectKey' | 'targetUrl'>,
+) {
+  const objectKey = getBackblazeObjectKey(input.currentUrl, manifest.sourceBucket);
+
+  if (!objectKey) {
+    manifest.skippedUrls.push({
+      source: input.source,
+      recordId: input.recordId,
+      projectId: input.projectId,
+      url: input.currentUrl,
+      reason: 'URL is not a recognized Backblaze object URL',
+    });
+    return;
+  }
+
+  const dedupeKey = `${input.source}:${input.recordId}:${objectKey}`;
+  if (seen.has(dedupeKey)) {
+    return;
+  }
+  seen.add(dedupeKey);
+
+  manifest.assets.push({
+    ...input,
+    objectKey,
+    targetUrl: `https://storage.googleapis.com/${manifest.targetBucket}/${objectKey}`,
+  });
+}
+
+function getBackblazeObjectKey(rawUrl: string, sourceBucket?: string): string | null {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const path = decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+  const bucketHost = sourceBucket ? `${sourceBucket}.s3.` : '.s3.';
+
+  if (url.hostname.includes(bucketHost)) {
+    return path;
+  }
+
+  if (sourceBucket && path.startsWith(`${sourceBucket}/`)) {
+    return path.slice(sourceBucket.length + 1);
+  }
+
+  if (url.hostname.endsWith('backblazeb2.com') && path.includes('/')) {
+    return path;
+  }
+
+  return null;
+}
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add an offline Backblaze -> GCS migration manifest script
- inventory image URLs from `Gallery.url`, `Project.imageBefore`, and `Project.imageAfter`
- map recognized Backblaze object keys to expected GCS public URLs
- write skipped/unrecognized URLs for manual review
- add a runbook for copy, validation, cutover, URL rewrite, and rollback

## Validation
- GCS_BUCKET_NAME=rakium-gcs-target BACKBLAZE_BUCKET_NAME=rakium-backblaze-source npm run storage:plan-gcs-migration
- npm.cmd test -- --runInBand
- npm.cmd run build
- git diff --check

## Notes
- This does not copy objects or rewrite database URLs.
- Local seed generated 0 migratable assets and 2 skipped example URLs, as expected.
- Real migration still needs explicit approval before running against production buckets.