### PR TITLE
Protect private project endpoints

### DIFF
--- a/src/projects/projects.controller.spec.ts
+++ b/src/projects/projects.controller.spec.ts
@@ -1,0 +1,33 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../auth/public.decorator';
+import { ProjectsController } from './projects.controller';
+
+describe('ProjectsController auth metadata', () => {
+  it('protects the controller with JwtAuthGuard by default', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, ProjectsController);
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('keeps only published project list endpoints public', () => {
+    expect(isPublic('findFeatured')).toBe(true);
+    expect(isPublic('findPublicByClientId')).toBe(true);
+    expect(isPublic('findPublishedProject')).toBe(true);
+  });
+
+  it('keeps private project management endpoints behind the controller guard', () => {
+    expect(isPublic('create')).toBeFalsy();
+    expect(isPublic('findAll')).toBeFalsy();
+    expect(isPublic('findAllByClientId')).toBeFalsy();
+    expect(isPublic('findOne')).toBeFalsy();
+    expect(isPublic('update')).toBeFalsy();
+    expect(isPublic('remove')).toBeFalsy();
+    expect(isPublic('reorderProjects')).toBeFalsy();
+    expect(isPublic('setProjectOrder')).toBeFalsy();
+  });
+
+  function isPublic(methodName: keyof ProjectsController) {
+    return Reflect.getMetadata(IS_PUBLIC_KEY, ProjectsController.prototype[methodName]);
+  }
+});

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, UseGuards } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto } from '../dto/create-project.dto';
 import { UpdateProjectDto } from '../dto/update-project.dto';
@@ -6,9 +6,11 @@ import { PaginationDto } from '../dto/pagination.dto';
 import { ProjectsQueryDto } from './dto/projects-query.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery, ApiBody, ApiParam } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('projects')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('projects')
 export class ProjectsController {
   constructor(private readonly projectsService: ProjectsService) {}
@@ -108,6 +110,7 @@ export class ProjectsController {
   @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page', example: 10 })
   @ApiQuery({ name: 'search', required: false, description: 'Search term to filter results', example: 'estación' })
   @Get('featured')
+  @Public()
   findFeatured(@Query() paginationDto: PaginationDto) {
     return this.projectsService.findFeatured(paginationDto);
   }
@@ -126,7 +129,6 @@ export class ProjectsController {
   }
 
   @Get('client/:clientId')
-  @Public()
   @ApiOperation({ summary: 'Get projects by client with pagination' })
   @ApiParam({ name: 'clientId', description: 'Client ID' })
   @ApiResponse({ status: 200, description: 'Paginated client project list' })
@@ -218,4 +220,4 @@ export class ProjectsController {
   ) {
     return this.projectsService.setProjectOrder(id, parseInt(order));
   }
-} 
+}


### PR DESCRIPTION
## Summary
- protect `ProjectsController` with `JwtAuthGuard` by default
- keep only published/read-only project endpoints public
- remove public access from `/projects/client/:clientId`, which returns all client projects
- add controller metadata tests so private project routes do not become public again accidentally

## Validation
- npm.cmd test -- --runInBand
- npm.cmd run build
- git diff --check
- local smoke on port 3002:
  - GET /api/projects without token -> 401
  - GET /api/projects/client/:clientId/public without token -> 200
  - GET /api/projects/:id/published without token -> 200

## Notes
- No server or production environment changes were made.