### PR TITLE
Epic follow-up: harden uploads, preflight Dokploy and GCS rewrite

### DIFF
--- a/DOKPLOY.md
+++ b/DOKPLOY.md
@@ -41,12 +41,26 @@ JWT_EXPIRATION=7d
 PORT=3000
 ```
 
-#### Variables Opcionales (para uploads a Backblaze B2)
+#### Variables Opcionales (para uploads)
+
+Backblaze sigue siendo el default si no se define `STORAGE_PROVIDER`:
 
 ```
+STORAGE_PROVIDER=backblaze
 BACKBLAZE_ACCESS_KEY_ID=tu-access-key-id
 BACKBLAZE_SECRET_ACCESS_KEY=tu-secret-access-key
 BACKBLAZE_BUCKET_NAME=nombre-de-tu-bucket
+```
+
+Para Google Cloud Storage:
+
+```
+STORAGE_PROVIDER=gcs
+GCS_BUCKET_NAME=nombre-de-tu-bucket
+GCS_PROJECT_ID=tu-project-id
+GCS_CLIENT_EMAIL=service-account@project.iam.gserviceaccount.com
+GCS_PRIVATE_KEY=tu-private-key-con-saltos-escapados
+GCS_PUBLIC_BASE_URL=https://storage.googleapis.com/nombre-de-tu-bucket
 ```
 
 #### Seguridad de Secretos

--- a/DOKPLOY.md
+++ b/DOKPLOY.md
@@ -58,9 +58,9 @@ Para Google Cloud Storage:
 STORAGE_PROVIDER=gcs
 GCS_BUCKET_NAME=nombre-de-tu-bucket
 GCS_PROJECT_ID=tu-project-id
-GCS_CLIENT_EMAIL=service-account@project.iam.gserviceaccount.com
-GCS_PRIVATE_KEY=tu-private-key-con-saltos-escapados
-GCS_PUBLIC_BASE_URL=https://storage.googleapis.com/nombre-de-tu-bucket
+GCS_SERVICE_ACCOUNT_JSON=service-account-json-escapado
+# o
+GOOGLE_APPLICATION_CREDENTIALS=/ruta/al/service-account.json
 ```
 
 #### Seguridad de Secretos

--- a/DOKPLOY_CUTOVER_CHECKLIST.md
+++ b/DOKPLOY_CUTOVER_CHECKLIST.md
@@ -1,0 +1,75 @@
+# Rakium BE Dokploy Cutover Checklist
+
+Use this checklist when moving production traffic from Railway to Dokploy. Do not paste real secrets, database URLs, dumps, or service account JSON into this file, PRs, or ClickUp.
+
+## Current Assumption
+
+- Railway remains the live production backend until this checklist is completed.
+- Dokploy is the target backend runtime.
+- PostgreSQL is the production database engine.
+- Backblaze remains the storage provider for the first backend cutover unless storage cutover is explicitly approved.
+
+## Pre-Cutover
+
+1. Confirm Railway is healthy at the current production API URL.
+2. Confirm the Dokploy app exists with:
+   - App name: `rakium-be`
+   - Build type: Dockerfile
+   - Dockerfile path: `Dockerfile`
+   - Docker context: `.`
+   - Internal port: `3000`
+   - Health check path: `/api`
+3. Configure Dokploy environment variables:
+   - `DATABASE_URL`
+   - `JWT_SECRET`
+   - `JWT_EXPIRATION`
+   - `PORT=3000`
+   - `CORS_ORIGINS`
+   - `STORAGE_PROVIDER=backblaze`
+   - `BACKBLAZE_ACCESS_KEY_ID`
+   - `BACKBLAZE_SECRET_ACCESS_KEY`
+   - `BACKBLAZE_BUCKET_NAME`
+4. Create a fresh Railway database backup.
+5. Import the backup into Dokploy Postgres using `DOKPLOY_DB_MIGRATION_RUNBOOK.md`.
+6. Run the database preflight against Dokploy Postgres:
+
+```bash
+DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DB?schema=public' npm run dokploy:preflight
+```
+
+7. If duplicate `(client_id, order)` rows are reported, fix them before deploying.
+8. Deploy the Dokploy app from the approved branch.
+9. Run smoke tests against the Dokploy API:
+
+```bash
+SMOKE_API_URL=https://<dokploy-api-domain>/api npm run smoke:api
+```
+
+## Manual QA
+
+1. Login works from the admin frontend.
+2. Public project pages load.
+3. Admin project list loads.
+4. Client project pages load.
+5. Existing gallery images load from Backblaze.
+6. Upload a test image only after Backblaze env vars are confirmed.
+7. Check Dokploy logs for startup migration output and runtime errors.
+
+## Traffic Cutover
+
+1. Keep Railway active.
+2. Point a test frontend/API configuration to the Dokploy API domain.
+3. Re-run smoke and manual QA.
+4. Update production frontend API URL only after QA passes.
+5. Watch Dokploy logs during the first production window.
+
+## Rollback
+
+1. Repoint frontend/API traffic to Railway.
+2. Keep Backblaze as storage by leaving `STORAGE_PROVIDER=backblaze`.
+3. If writes happened on Dokploy during the failed window, decide whether to replay them or restore Railway data before switching back.
+4. Redeploy the previous known-good backend commit if the issue is code-related.
+
+## Separate Storage Cutover
+
+Backblaze to GCS is a separate operation. Use `STORAGE_MIGRATION_BACKBLAZE_TO_GCS.md` only after the backend cutover is stable.

--- a/DOKPLOY_PRODUCTION_RUNBOOK.md
+++ b/DOKPLOY_PRODUCTION_RUNBOOK.md
@@ -48,9 +48,9 @@ When Google Cloud Storage is ready:
 STORAGE_PROVIDER=gcs
 GCS_BUCKET_NAME=<bucket>
 GCS_PROJECT_ID=<project-id>
-GCS_CLIENT_EMAIL=<service-account-email>
-GCS_PRIVATE_KEY=<service-account-private-key-with-newlines-escaped>
-GCS_PUBLIC_BASE_URL=https://storage.googleapis.com/<bucket>
+GCS_SERVICE_ACCOUNT_JSON=<escaped-service-account-json>
+# or
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 ```
 
 ## Preflight before first deploy

--- a/DOKPLOY_PRODUCTION_RUNBOOK.md
+++ b/DOKPLOY_PRODUCTION_RUNBOOK.md
@@ -58,7 +58,15 @@ GCS_PUBLIC_BASE_URL=https://storage.googleapis.com/<bucket>
 1. Confirm Railway is still serving production.
 2. Create a fresh database backup.
 3. Import the database into Dokploy Postgres using `DOKPLOY_DB_MIGRATION_RUNBOOK.md`.
-4. Run this duplicate-order check before deploying migrations:
+4. Run the automated preflight:
+
+```bash
+DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DB?schema=public' npm run dokploy:preflight
+```
+
+This checks table counts, duplicate project ordering per client, and storage environment completeness. The duplicate-order check is the blocker because the schema enforces a unique `(client_id, order)` index.
+
+You can also run the SQL manually:
 
 ```sql
 SELECT client_id, "order", COUNT(*)

--- a/GCP_GCS_SETUP_PLAN.md
+++ b/GCP_GCS_SETUP_PLAN.md
@@ -4,18 +4,29 @@ This is the setup plan for the future Backblaze to Google Cloud Storage migratio
 
 ## Resources To Create
 
-- Google Cloud project: use an existing Rakium/Adrian project if one already exists; otherwise create a dedicated project such as `rakium-prod`.
-- Cloud Storage bucket: `rakium-prod-assets` or another globally unique variant.
-- Bucket location: `us-central1` unless there is a stronger latency/compliance reason to choose another region.
-- Service account: `rakium-be-storage`.
-- Service account role: prefer bucket-scoped `roles/storage.objectAdmin` on the target bucket.
+- Google Cloud project: `rakium-prod-401022`.
+- Cloud Storage bucket: `rakium-prod-assets-401022`.
+- Bucket location: `us-central1`.
+- Service account: `rakium-be-storage@rakium-prod-401022.iam.gserviceaccount.com`.
+- Service account role: bucket-scoped `roles/storage.objectAdmin` on `rakium-prod-assets-401022`.
+- Public read role: bucket-scoped `roles/storage.objectViewer` for `allUsers`.
+
+## Current Status
+
+- Project created.
+- Billing linked.
+- Cloud Storage/IAM APIs enabled.
+- Bucket created with uniform bucket-level access.
+- Public object reads verified.
+- Service account key created at `.tmp/gcp/rakium-be-storage-key.json`; this path is ignored by Git.
+- Smoke upload/read/delete verified with `@google-cloud/storage`.
 
 ## Backend Environment Variables
 
 ```bash
 STORAGE_PROVIDER=gcs
-GCS_BUCKET_NAME=<bucket>
-GCS_PROJECT_ID=<project-id>
+GCS_BUCKET_NAME=rakium-prod-assets-401022
+GCS_PROJECT_ID=rakium-prod-401022
 GCS_SERVICE_ACCOUNT_JSON=<escaped-service-account-json>
 ```
 
@@ -27,27 +38,31 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 ## CLI Flow
 
-After `gcloud auth login` and project selection:
+Already executed for the current setup:
 
 ```bash
 gcloud services enable storage.googleapis.com
 
-gcloud storage buckets create gs://<bucket> \
-  --project=<project-id> \
+gcloud storage buckets create gs://rakium-prod-assets-401022 \
+  --project=rakium-prod-401022 \
   --location=us-central1 \
   --uniform-bucket-level-access
 
+gcloud storage buckets add-iam-policy-binding gs://rakium-prod-assets-401022 \
+  --member="allUsers" \
+  --role="roles/storage.objectViewer"
+
 gcloud iam service-accounts create rakium-be-storage \
-  --project=<project-id> \
+  --project=rakium-prod-401022 \
   --display-name="Rakium BE Storage"
 
-gcloud storage buckets add-iam-policy-binding gs://<bucket> \
-  --member="serviceAccount:rakium-be-storage@<project-id>.iam.gserviceaccount.com" \
+gcloud storage buckets add-iam-policy-binding gs://rakium-prod-assets-401022 \
+  --member="serviceAccount:rakium-be-storage@rakium-prod-401022.iam.gserviceaccount.com" \
   --role="roles/storage.objectAdmin"
 
 gcloud iam service-accounts keys create .tmp/gcp/rakium-be-storage-key.json \
-  --iam-account="rakium-be-storage@<project-id>.iam.gserviceaccount.com" \
-  --project=<project-id>
+  --iam-account="rakium-be-storage@rakium-prod-401022.iam.gserviceaccount.com" \
+  --project=rakium-prod-401022
 ```
 
 ## Safety

--- a/GCP_GCS_SETUP_PLAN.md
+++ b/GCP_GCS_SETUP_PLAN.md
@@ -1,0 +1,58 @@
+# Rakium GCS Setup Plan
+
+This is the setup plan for the future Backblaze to Google Cloud Storage migration. Do not store real credentials or service account JSON in this file.
+
+## Resources To Create
+
+- Google Cloud project: use an existing Rakium/Adrian project if one already exists; otherwise create a dedicated project such as `rakium-prod`.
+- Cloud Storage bucket: `rakium-prod-assets` or another globally unique variant.
+- Bucket location: `us-central1` unless there is a stronger latency/compliance reason to choose another region.
+- Service account: `rakium-be-storage`.
+- Service account role: prefer bucket-scoped `roles/storage.objectAdmin` on the target bucket.
+
+## Backend Environment Variables
+
+```bash
+STORAGE_PROVIDER=gcs
+GCS_BUCKET_NAME=<bucket>
+GCS_PROJECT_ID=<project-id>
+GCS_SERVICE_ACCOUNT_JSON=<escaped-service-account-json>
+```
+
+For a server-local credentials file, use this instead of `GCS_SERVICE_ACCOUNT_JSON`:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+## CLI Flow
+
+After `gcloud auth login` and project selection:
+
+```bash
+gcloud services enable storage.googleapis.com
+
+gcloud storage buckets create gs://<bucket> \
+  --project=<project-id> \
+  --location=us-central1 \
+  --uniform-bucket-level-access
+
+gcloud iam service-accounts create rakium-be-storage \
+  --project=<project-id> \
+  --display-name="Rakium BE Storage"
+
+gcloud storage buckets add-iam-policy-binding gs://<bucket> \
+  --member="serviceAccount:rakium-be-storage@<project-id>.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+
+gcloud iam service-accounts keys create .tmp/gcp/rakium-be-storage-key.json \
+  --iam-account="rakium-be-storage@<project-id>.iam.gserviceaccount.com" \
+  --project=<project-id>
+```
+
+## Safety
+
+- Keep Backblaze active for the first Dokploy backend cutover.
+- Do not switch `STORAGE_PROVIDER=gcs` until upload/read checks pass.
+- Do not rewrite database URLs until objects are copied, validated, and the database is backed up.
+- Delete or move service account key files out of the repo workspace after storing the secret in the deployment platform.

--- a/STORAGE_MIGRATION_BACKBLAZE_TO_GCS.md
+++ b/STORAGE_MIGRATION_BACKBLAZE_TO_GCS.md
@@ -102,18 +102,28 @@ Existing database URLs still point to Backblaze until URL rewrite is done.
 
 ## 5. URL rewrite plan
 
-After object copy is validated, create a separate PR or one-time migration script to update:
+After object copy is validated, use the manifest to rewrite:
 
 - `Gallery.url`
 - `Project.imageBefore`
 - `Project.imageAfter`
 
-Use the generated manifest as the source of truth:
+Dry run first:
 
-- Replace each `currentUrl` with `targetUrl`.
-- Wrap updates in a transaction.
-- Take a database backup first.
-- Keep Backblaze objects for rollback until the frontend has been verified against rewritten URLs.
+```bash
+DATABASE_URL="postgresql://user:password@host:5432/db?schema=public" \
+npm run storage:rewrite-gcs-urls
+```
+
+Apply only after a database backup and object-copy validation:
+
+```bash
+DATABASE_URL="postgresql://user:password@host:5432/db?schema=public" \
+STORAGE_MIGRATION_APPLY=true \
+npm run storage:rewrite-gcs-urls
+```
+
+The script uses `currentUrl` guards in each update, so it will not overwrite rows that changed after the manifest was generated. Keep Backblaze objects for rollback until the frontend has been verified against rewritten URLs.
 
 ## 6. Rollback
 

--- a/bruno/rakium-api/README.md
+++ b/bruno/rakium-api/README.md
@@ -1,152 +1,61 @@
-# Rakium API - Colección de Bruno
+# Rakium API Bruno collection
 
-Esta colección de Bruno contiene todos los endpoints de la API de Rakium para testing y desarrollo.
+This Bruno collection contains the main Rakium API endpoints for local and production smoke testing.
 
-## 🚀 Configuración Inicial
+## Setup
 
-### 1. Importar la colección
-1. Abre Bruno
-2. Haz clic en "Import Collection"
-3. Selecciona la carpeta `bruno/rakium-api`
+1. Import `bruno/rakium-api` into Bruno.
+2. Select the `Local` or `Production` environment.
+3. Run `Auth / Login` first.
+4. The login request stores the bearer token in `authToken`.
+5. Run list endpoints to populate IDs such as `clientId`, `projectId`, `galleryId`, and `videoId`.
 
-### 2. Configurar variables de entorno
-1. Selecciona el entorno "Production" o "Local"
-2. Ejecuta primero el endpoint "Login" para obtener el token de autenticación
-3. El token se guardará automáticamente en la variable `authToken`
+## Endpoint groups
 
-### 3. Obtener IDs necesarios
-1. Ejecuta "Get All Clients" para obtener un `clientId`
-2. Los IDs se guardarán automáticamente en las variables de entorno
+### Auth
 
-## 📋 Estructura de la Colección
+- `Login`: public login endpoint.
+- `Get Profile`: authenticated profile endpoint.
+- `Test Auth`: authenticated token check.
 
-### 🔐 Auth (3 endpoints)
-- **Login** - Autenticación y obtención de token
-- **Get Profile** - Información del usuario autenticado
-- **Test Auth** - Verificar autenticación
+### Projects
 
-### 📁 Projects (10 endpoints)
-- **Get All Projects** - Listar todos los proyectos con paginación
-- **Create Project** - Crear nuevo proyecto (incluye nuevos campos: githubUrl, demoUrl, technologies)
-- **Get Project by ID** - Obtener proyecto específico
-- **Update Project** - Actualizar proyecto
-- **Get Featured Projects** - Proyectos destacados
-- **Get Published Project (Public)** - Proyecto publicado (público)
-- **Get Projects by Client (Public)** - Proyectos por cliente (público)
-- **Reorder Projects** - Reordenar proyectos
-- **Set Project Order** - Establecer orden específico
-- **Delete Project** - Eliminar proyecto
+- Private management endpoints require bearer auth.
+- Public routes only expose published project data.
+- Reorder and order update requests require bearer auth.
 
-### 👥 Clients (5 endpoints)
-- **Get All Clients** - Listar todos los clientes
-- **Create Client** - Crear nuevo cliente
-- **Get Client by ID** - Obtener cliente específico
-- **Update Client** - Actualizar cliente
-- **Delete Client** - Eliminar cliente
+### Clients and Users
 
-### 👤 Users (5 endpoints)
-- **Get All Users** - Listar todos los usuarios
-- **Create User** - Crear nuevo usuario
-- **Get User by ID** - Obtener usuario específico
-- **Update User** - Actualizar usuario
-- **Delete User** - Eliminar usuario
+- All client and user management endpoints require bearer auth.
+- User responses are expected to omit `passwordHash`.
 
-### 🖼️ Gallery (7 endpoints)
-- **Get Gallery Images** - Listar imágenes de galería
-- **Get Public Gallery** - Galería pública
-- **Add Gallery Image** - Agregar imagen a galería
-- **Get Gallery Image by ID** - Obtener imagen específica
-- **Update Gallery Image** - Actualizar imagen
-- **Reorder Gallery Images** - Reordenar imágenes
-- **Delete Gallery Image** - Eliminar imagen
+### Gallery
 
-### 🎥 Videos (7 endpoints)
-- **Get All Videos** - Listar todos los videos
-- **Get Public Videos** - Videos públicos
-- **Add Video** - Agregar video de YouTube
-- **Get Video by ID** - Obtener video específico
-- **Update Video** - Actualizar video
-- **Reorder Videos** - Reordenar videos
-- **Delete Video** - Eliminar video
+- Public gallery routes only return gallery data for published projects.
+- Gallery create, upload, update, reorder, and delete require bearer auth.
 
-### 📤 Upload (5 endpoints)
-- **Test Upload (Public)** - Upload de prueba (público)
-- **Upload File** - Subir archivo a Backblaze B2
-- **Upload Image with Variants** - Subir imagen con variantes optimizadas
-- **Upload to Project Gallery** - Subir directamente a galería de proyecto
-- **Upload Image Variants** - Subir imagen con múltiples variantes
+### Videos
 
-## 🆕 Nuevos Campos en Projects
+- Public video routes only return videos for published projects.
+- Video create, update, reorder, and delete require bearer auth.
 
-Los proyectos ahora incluyen los siguientes campos nuevos:
+### Upload
 
-### `githubUrl` (string, nullable)
-- URL del repositorio de GitHub del proyecto
-- Ejemplo: `"https://github.com/usuario/proyecto"`
+- `Test Upload`: protected upload test endpoint.
+- `Upload File`: uploads to the configured storage provider.
+- `Upload Image with Variants`: protected image variants endpoint.
+- `Upload to Project Gallery`: protected project gallery upload.
+- `Upload Image Variants`: protected variants endpoint.
 
-### `demoUrl` (string, nullable)
-- URL de demostración del proyecto
-- Ejemplo: `"https://demo-proyecto.com"`
+## URLs
 
-### `technologies` (JSON array, nullable)
-- Array de tecnologías utilizadas (funciona como chips)
-- **Entrada**: `"React, TypeScript, Node.js"`
-- **Salida**: `["React", "TypeScript", "Node.js"]`
+- Production: `https://rakium-be-production.up.railway.app`
+- Local: `http://localhost:3000`
+- Swagger: `{{baseUrl}}/api`
 
-## 🔄 Flujo de Testing Recomendado
+## Notes
 
-1. **Autenticación**
-   - Ejecutar "Login" para obtener token
-
-2. **Configuración inicial**
-   - Ejecutar "Get All Clients" para obtener clientId
-   - Ejecutar "Get All Projects" para ver proyectos existentes
-
-3. **Testing CRUD completo**
-   - Crear proyecto con nuevos campos
-   - Actualizar proyecto
-   - Agregar imágenes a galería
-   - Agregar videos
-   - Probar endpoints públicos
-
-4. **Testing de upload**
-   - Probar upload de archivos
-   - Probar upload con variantes
-   - Probar upload directo a galería
-
-5. **Limpieza**
-   - Eliminar recursos creados durante las pruebas
-
-## 🌐 URLs de la API
-
-- **Producción**: `https://rakium-be-production.up.railway.app`
-- **Local**: `http://localhost:3000`
-- **Swagger**: `https://rakium-be-production.up.railway.app/api`
-
-## 📝 Notas Importantes
-
-- Todos los endpoints que requieren autenticación usan Bearer Token
-- Los endpoints marcados como "Public" no requieren autenticación
-- Las variables de entorno se actualizan automáticamente durante las pruebas
-- Los archivos de prueba deben estar en la carpeta raíz del proyecto
-- La colección incluye tests automatizados para validar respuestas
-
-## 🐛 Troubleshooting
-
-### Error 401 (Unauthorized)
-- Verificar que el token de autenticación esté configurado
-- Ejecutar "Login" nuevamente para obtener un token fresco
-
-### Error 404 (Not Found)
-- Verificar que los IDs en las variables de entorno sean correctos
-- Ejecutar los endpoints de "Get All" para obtener IDs válidos
-
-### Error 400 (Bad Request)
-- Verificar que el body de la petición tenga el formato correcto
-- Revisar que los campos requeridos estén presentes
-
----
-
-**Fecha de creación**: 17 de Agosto, 2024
-**Versión de la API**: 1.0
-**Última actualización**: Incluye nuevos campos githubUrl, demoUrl y technologies
+- Endpoints marked public in the collection do not send a token.
+- Every other endpoint must use `Authorization: Bearer {{authToken}}`.
+- Upload requests need `test-image.png` available where Bruno can read it.
+- Keep production secrets out of collection files and environment commits.

--- a/bruno/rakium-api/upload/Test Upload.bru
+++ b/bruno/rakium-api/upload/Test Upload.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Test Upload (Public)
+  name: Test Upload
   type: http
   seq: 1
 }
@@ -7,7 +7,11 @@ meta {
 post {
   url: {{baseUrl}}/upload/test
   body: multipartForm
-  auth: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
 }
 
 body:multipart-form {
@@ -16,6 +20,7 @@ body:multipart-form {
 
 vars:pre-request {
   baseUrl: https://rakium-be-production.up.railway.app
+  authToken: bruno.getEnvironmentVar("authToken")
 }
 
 tests {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "assign-lautarovulcano": "ts-node scripts/assign-lautarovulcano-client.ts",
     "storage:plan-gcs-migration": "ts-node scripts/plan-backblaze-to-gcs-migration.ts",
     "smoke:api": "ts-node scripts/smoke-api.ts",
+    "dokploy:preflight": "ts-node scripts/dokploy-preflight.ts",
     "db:migrate": "prisma migrate deploy",
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "seed": "ts-node prisma/seed.ts",
     "assign-lautarovulcano": "ts-node scripts/assign-lautarovulcano-client.ts",
     "storage:plan-gcs-migration": "ts-node scripts/plan-backblaze-to-gcs-migration.ts",
+    "storage:rewrite-gcs-urls": "ts-node scripts/rewrite-storage-urls-to-gcs.ts",
     "smoke:api": "ts-node scripts/smoke-api.ts",
     "dokploy:preflight": "ts-node scripts/dokploy-preflight.ts",
     "db:migrate": "prisma migrate deploy",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,3 +66,13 @@ SMOKE_UPLOAD_FILE=./path/to/image.jpg
 ```
 
 The smoke test validates login, `auth/me`, private project permissions, public project routes, and upload auth. The authenticated upload is skipped unless `SMOKE_UPLOAD_FILE` is set.
+
+## `dokploy-preflight.ts`
+
+Runs preflight checks against the database that will be used by Dokploy:
+
+```bash
+DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DB?schema=public' npm run dokploy:preflight
+```
+
+It prints table counts, fails on duplicate `(client_id, order)` project values, and warns when storage env vars for the selected `STORAGE_PROVIDER` are missing.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,3 +76,21 @@ DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DB?schema=public' npm run dok
 ```
 
 It prints table counts, fails on duplicate `(client_id, order)` project values, and warns when storage env vars for the selected `STORAGE_PROVIDER` are missing.
+
+## `rewrite-storage-urls-to-gcs.ts`
+
+Uses the Backblaze to GCS manifest to rewrite database URLs after objects have been copied and validated.
+
+Dry run:
+
+```bash
+npm run storage:rewrite-gcs-urls
+```
+
+Apply:
+
+```bash
+STORAGE_MIGRATION_APPLY=true npm run storage:rewrite-gcs-urls
+```
+
+The script updates rows only when the current database URL still matches the manifest `currentUrl`.

--- a/scripts/dokploy-preflight.ts
+++ b/scripts/dokploy-preflight.ts
@@ -1,0 +1,84 @@
+import { PrismaClient } from '@prisma/client';
+
+type DuplicateProjectOrder = {
+  client_id: string;
+  order: number;
+  count: bigint;
+};
+
+type CountRow = {
+  label: string;
+  count: bigint;
+};
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Dokploy preflight checks');
+
+  const counts = await prisma.$queryRaw<CountRow[]>`
+    SELECT 'clients' AS label, COUNT(*)::bigint AS count FROM "Client"
+    UNION ALL
+    SELECT 'users' AS label, COUNT(*)::bigint AS count FROM "User"
+    UNION ALL
+    SELECT 'projects' AS label, COUNT(*)::bigint AS count FROM projects
+    UNION ALL
+    SELECT 'gallery' AS label, COUNT(*)::bigint AS count FROM "Gallery"
+    UNION ALL
+    SELECT 'videos' AS label, COUNT(*)::bigint AS count FROM "Video"
+  `;
+
+  for (const row of counts) {
+    console.log(`- ${row.label}: ${row.count.toString()}`);
+  }
+
+  const duplicateOrders = await prisma.$queryRaw<DuplicateProjectOrder[]>`
+    SELECT client_id, "order", COUNT(*)::bigint AS count
+    FROM projects
+    GROUP BY client_id, "order"
+    HAVING COUNT(*) > 1
+    ORDER BY client_id, "order"
+  `;
+
+  if (duplicateOrders.length > 0) {
+    console.error('');
+    console.error('BLOCKER: duplicate project order values found per client.');
+    for (const row of duplicateOrders) {
+      console.error(`- client_id=${row.client_id} order=${row.order} count=${row.count.toString()}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('- duplicate project order values: none');
+
+  const storageProvider = process.env.STORAGE_PROVIDER || 'backblaze';
+  console.log(`- STORAGE_PROVIDER: ${storageProvider}`);
+
+  if (storageProvider === 'gcs' || storageProvider === 'google-cloud-storage') {
+    requireEnv(['GCS_BUCKET_NAME', 'GCS_PROJECT_ID', 'GCS_CLIENT_EMAIL', 'GCS_PRIVATE_KEY']);
+  } else {
+    requireEnv(['BACKBLAZE_ACCESS_KEY_ID', 'BACKBLAZE_SECRET_ACCESS_KEY', 'BACKBLAZE_BUCKET_NAME']);
+  }
+
+  console.log('Preflight completed.');
+}
+
+function requireEnv(names: string[]) {
+  const missing = names.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    console.warn(`- storage env warning: missing ${missing.join(', ')}`);
+    return;
+  }
+
+  console.log('- storage env variables: present');
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/dokploy-preflight.ts
+++ b/scripts/dokploy-preflight.ts
@@ -56,7 +56,8 @@ async function main() {
   console.log(`- STORAGE_PROVIDER: ${storageProvider}`);
 
   if (storageProvider === 'gcs' || storageProvider === 'google-cloud-storage') {
-    requireEnv(['GCS_BUCKET_NAME', 'GCS_PROJECT_ID', 'GCS_CLIENT_EMAIL', 'GCS_PRIVATE_KEY']);
+    requireEnv(['GCS_BUCKET_NAME']);
+    requireAnyEnv(['GCS_SERVICE_ACCOUNT_JSON', 'GOOGLE_APPLICATION_CREDENTIALS']);
   } else {
     requireEnv(['BACKBLAZE_ACCESS_KEY_ID', 'BACKBLAZE_SECRET_ACCESS_KEY', 'BACKBLAZE_BUCKET_NAME']);
   }
@@ -72,6 +73,15 @@ function requireEnv(names: string[]) {
   }
 
   console.log('- storage env variables: present');
+}
+
+function requireAnyEnv(names: string[]) {
+  if (names.some((name) => process.env[name])) {
+    console.log(`- storage auth env variable: present (${names.join(' or ')})`);
+    return;
+  }
+
+  console.warn(`- storage env warning: missing one of ${names.join(', ')}`);
 }
 
 main()

--- a/scripts/import-dump-dokploy.md
+++ b/scripts/import-dump-dokploy.md
@@ -1,95 +1,47 @@
-# Cómo Importar el Dump en Dokploy
+# Importar dump en Dokploy
 
-Como el hostname de la base de datos de Dokploy suele ser interno de Docker, necesitas ejecutar la importación desde dentro de la red de Dokploy.
+La base de datos de Dokploy suele vivir en una red interna de Docker. Por eso, la importacion debe ejecutarse desde el servidor o desde un contenedor temporal que pueda ver esa red.
 
-## Opción 1: Usar el Terminal/Console de Dokploy (Más Fácil)
+## Opcion 1: Terminal de Dokploy
 
-1. **En el panel de Dokploy, ve a tu aplicación "Backend"**
-2. **Busca la opción "Terminal", "Console", "Execute" o "Run Command"**
-3. **Sube el archivo de dump:**
-   - Busca una opción para subir archivos o usar un volumen
-   - O copia el contenido del dump y pégalo en un archivo temporal
-
-4. **Ejecuta el comando de importación:**
-   ```bash
-   # Si tienes psql disponible en el contenedor
-   psql 'postgresql://usuario:password@dokploy-db-host:5432/rakium_production' < /ruta/al/dump.sql
-   
-   # O usando el cliente de Prisma (si está disponible)
-   npx prisma db execute --file /ruta/al/dump.sql --schema prisma/schema.prisma
-   ```
-
-## Opción 2: Crear un Contenedor Temporal en Dokploy
-
-1. **En Dokploy, crea una nueva aplicación temporal:**
-   - Nombre: `db-import-temp`
-   - Tipo: Docker Image
-   - Imagen: `postgres:16-alpine`
-   - Red: Misma red que `dokploy-db-host`
-
-2. **Sube el archivo de dump al contenedor** (usando volúmenes o upload)
-
-3. **Ejecuta el comando de importación:**
-   ```bash
-   psql 'postgresql://usuario:password@dokploy-db-host:5432/rakium_production' < /dumps/railway-dump-YYYYMMDD-HHMMSS.sql
-   ```
-
-4. **Elimina el contenedor temporal** después de la importación
-
-## Opción 3: Usar Docker Compose o CLI desde el Servidor
-
-Si tienes acceso SSH al servidor donde corre Dokploy:
+1. Abre el terminal/console de la aplicacion o del servicio de base de datos.
+2. Sube el dump por un canal temporal seguro.
+3. Ejecuta:
 
 ```bash
-# Conectarte al servidor
-ssh usuario@servidor-dokploy
+psql 'postgresql://USER:PASSWORD@DOKPLOY_DB_HOST:5432/DB?schema=public' < /ruta/al/dump.sql
+```
 
-# Navegar al directorio de Dokploy (ajusta la ruta)
-cd /ruta/dokploy
+## Opcion 2: Contenedor temporal
 
-# Subir el dump al servidor primero
-# (desde tu máquina local)
-scp ./dumps/railway-dump-YYYYMMDD-HHMMSS.sql usuario@servidor:/tmp/
+Desde el servidor de Dokploy:
 
-# En el servidor, ejecutar:
+```bash
 docker run --rm -i \
   --network dokploy_default \
-  -v /tmp:/dumps \
+  -v /tmp/rakium-dumps:/dumps \
   postgres:16-alpine \
-  psql 'postgresql://usuario:password@dokploy-db-host:5432/rakium_production' < /dumps/railway-dump-YYYYMMDD-HHMMSS.sql
+  psql 'postgresql://USER:PASSWORD@DOKPLOY_DB_HOST:5432/DB?schema=public' \
+  < /dumps/railway-dump-YYYYMMDD-HHMMSS.sql
 ```
 
-## Opción 4: Usar Prisma Studio o Migraciones
-
-Si Dokploy tiene acceso a ejecutar comandos en tu aplicación Backend:
-
-1. **Sube el dump a un lugar accesible** (S3, volumen, etc.)
-
-2. **Modifica temporalmente el Dockerfile** para importar el dump al iniciar:
-   ```dockerfile
-   # Agregar al final del Dockerfile antes del CMD
-   # No copies dumps into Docker images. Upload the dump to the server temporarily instead.
-   ```
-
-3. **Modifica el CMD** para importar antes de iniciar:
-   ```dockerfile
-   CMD ["sh", "-c", "psql $DATABASE_URL < /tmp/dump.sql && node dist/src/main"]
-   ```
-
-4. **Despliega y luego revierte los cambios**
-
-## Verificación
-
-Después de importar, verifica que los datos estén correctos:
+Despues de importar, elimina el dump:
 
 ```bash
-# Desde el terminal de Dokploy o un contenedor con acceso
-psql 'postgresql://usuario:password@dokploy-db-host:5432/rakium_production' -c "SELECT COUNT(*) FROM \"Client\";"
-psql 'postgresql://usuario:password@dokploy-db-host:5432/rakium_production' -c "SELECT COUNT(*) FROM projects;"
+rm -f /tmp/rakium-dumps/railway-dump-*.sql
 ```
 
-## Notas Importantes
+## Verificacion
 
-- ⚠️ **El dump sobrescribirá todos los datos existentes** en la base de datos
-- ✅ Asegúrate de tener un backup antes de importar
-- ✅ Mantén los dumps fuera de Git y bórralos del servidor después de importar
+```bash
+psql 'postgresql://USER:PASSWORD@DOKPLOY_DB_HOST:5432/DB?schema=public' -c 'SELECT COUNT(*) FROM "Client";'
+psql 'postgresql://USER:PASSWORD@DOKPLOY_DB_HOST:5432/DB?schema=public' -c 'SELECT COUNT(*) FROM projects;'
+```
+
+## Reglas de seguridad
+
+- No copies dumps dentro de la imagen de la aplicacion.
+- No modifiques el Dockerfile para importar dumps.
+- No cambies el comando de arranque de produccion para importar datos.
+- No subas dumps ni URLs reales al repositorio.
+- Borra el dump del servidor despues de validar la importacion.

--- a/scripts/rewrite-storage-urls-to-gcs.ts
+++ b/scripts/rewrite-storage-urls-to-gcs.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { Prisma, PrismaClient } from '@prisma/client';
+
+type AssetSource = 'gallery.url' | 'project.imageBefore' | 'project.imageAfter';
+
+interface AssetReference {
+  source: AssetSource;
+  recordId: string;
+  projectId?: string;
+  currentUrl: string;
+  objectKey: string;
+  targetUrl: string;
+}
+
+interface MigrationManifest {
+  generatedAt: string;
+  assets: AssetReference[];
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const manifestPath = resolve(
+    process.env.STORAGE_MIGRATION_MANIFEST_PATH ?? '.tmp/storage-migration/backblaze-to-gcs-manifest.json',
+  );
+  const apply = process.env.STORAGE_MIGRATION_APPLY === 'true';
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as MigrationManifest;
+  const operations: Prisma.PrismaPromise<unknown>[] = [];
+
+  for (const asset of manifest.assets) {
+    if (asset.currentUrl === asset.targetUrl) {
+      continue;
+    }
+
+    if (asset.source === 'gallery.url') {
+      operations.push(
+        prisma.gallery.updateMany({
+          where: {
+            id: asset.recordId,
+            url: asset.currentUrl,
+          },
+          data: {
+            url: asset.targetUrl,
+          },
+        }),
+      );
+    }
+
+    if (asset.source === 'project.imageBefore') {
+      operations.push(
+        prisma.project.updateMany({
+          where: {
+            id: asset.recordId,
+            imageBefore: asset.currentUrl,
+          },
+          data: {
+            imageBefore: asset.targetUrl,
+          },
+        }),
+      );
+    }
+
+    if (asset.source === 'project.imageAfter') {
+      operations.push(
+        prisma.project.updateMany({
+          where: {
+            id: asset.recordId,
+            imageAfter: asset.currentUrl,
+          },
+          data: {
+            imageAfter: asset.targetUrl,
+          },
+        }),
+      );
+    }
+  }
+
+  console.log(`Manifest: ${manifestPath}`);
+  console.log(`Generated at: ${manifest.generatedAt}`);
+  console.log(`Assets in manifest: ${manifest.assets.length}`);
+  console.log(`Pending DB rewrite operations: ${operations.length}`);
+
+  if (!apply) {
+    console.log('Dry run only. Set STORAGE_MIGRATION_APPLY=true to rewrite database URLs.');
+    return;
+  }
+
+  if (operations.length === 0) {
+    console.log('No URL rewrites needed.');
+    return;
+  }
+
+  const results = await prisma.$transaction(operations);
+  const changedRows = results.reduce<number>((total, result) => {
+    const count = typeof result === 'object' && result && 'count' in result ? Number(result.count) : 0;
+    return total + count;
+  }, 0);
+
+  console.log(`Database URLs rewritten: ${changedRows}`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/smoke-api.ts
+++ b/scripts/smoke-api.ts
@@ -72,6 +72,16 @@ async function main() {
     expectStatus(response, [401]);
   });
 
+  await check('upload/test rejects anonymous requests', async () => {
+    const form = new FormData();
+    form.append('folder', 'smoke');
+    const response = await request('/upload/test', {
+      method: 'POST',
+      body: form,
+    });
+    expectStatus(response, [401]);
+  });
+
   if (uploadFilePath) {
     await check('authenticated upload/file accepts image file', async () => {
       const file = readFileSync(uploadFilePath);

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,22 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { IS_PUBLIC_KEY } from './public.decorator';
+import { AuthController } from './auth.controller';
+
+describe('AuthController auth metadata', () => {
+  it('protects the controller with JwtAuthGuard by default', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, AuthController);
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('keeps login public and protects profile endpoints', () => {
+    expect(isPublic('login')).toBe(true);
+    expect(isPublic('getProfile')).toBeFalsy();
+    expect(isPublic('testAuth')).toBeFalsy();
+  });
+
+  function isPublic(methodName: keyof AuthController) {
+    return Reflect.getMetadata(IS_PUBLIC_KEY, AuthController.prototype[methodName]);
+  }
+});

--- a/src/gallery/gallery.controller.spec.ts
+++ b/src/gallery/gallery.controller.spec.ts
@@ -1,0 +1,31 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../auth/public.decorator';
+import { GalleryController } from './gallery.controller';
+
+describe('GalleryController auth metadata', () => {
+  it('protects the controller with JwtAuthGuard by default', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, GalleryController);
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('keeps only published-gallery read routes public', () => {
+    expect(isPublic('findPublicGallery')).toBe(true);
+    expect(isPublic('getPublicGallery')).toBe(true);
+  });
+
+  it('keeps gallery write and private read routes behind the controller guard', () => {
+    expect(isPublic('uploadImage')).toBeFalsy();
+    expect(isPublic('create')).toBeFalsy();
+    expect(isPublic('findAll')).toBeFalsy();
+    expect(isPublic('findOne')).toBeFalsy();
+    expect(isPublic('update')).toBeFalsy();
+    expect(isPublic('remove')).toBeFalsy();
+    expect(isPublic('reorder')).toBeFalsy();
+  });
+
+  function isPublic(methodName: keyof GalleryController) {
+    return Reflect.getMetadata(IS_PUBLIC_KEY, GalleryController.prototype[methodName]);
+  }
+});

--- a/src/gallery/gallery.controller.ts
+++ b/src/gallery/gallery.controller.ts
@@ -148,6 +148,6 @@ export class GalleryController {
   @ApiQuery({ name: 'page', required: false, description: 'Page number (starts from 1)', example: 1 })
   @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page', example: 10 })
   async getPublicGallery(@Param('projectId') projectId: string, @Query() paginationDto: PaginationDto) {
-    return this.galleryService.findAll(projectId, paginationDto);
+    return this.galleryService.findPublicGallery(projectId, paginationDto);
   }
 } 

--- a/src/gallery/gallery.service.ts
+++ b/src/gallery/gallery.service.ts
@@ -68,7 +68,7 @@ export class GalleryService {
       throw new BadRequestException('No se pueden agregar más de 10 imágenes a la galería');
     }
 
-    // Subir archivo a Backblaze B2 con optimización automática
+    // Subir archivo al storage configurado con optimización automática
     const folder = `projects/${projectId}/gallery`;
     const url = await this.uploadService.uploadFile(file, folder, true); // optimize = true
 
@@ -214,7 +214,7 @@ export class GalleryService {
       throw new NotFoundException(`Gallery item with ID ${id} not found in project ${projectId}`);
     }
 
-    // Eliminar archivo de Backblaze B2 si existe
+    // Eliminar archivo del storage configurado si existe
     if (gallery.url) {
       try {
         await this.uploadService.deleteFile(gallery.url);

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -166,22 +166,6 @@ export class ProjectsController {
     return this.projectsService.findPublishedProject(id);
   }
 
-  @ApiOperation({ summary: 'Update a project' })
-  @ApiResponse({ status: 200, description: 'Project updated successfully' })
-  @ApiResponse({ status: 404, description: 'Project not found' })
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateProjectDto: UpdateProjectDto) {
-    return this.projectsService.update(id, updateProjectDto);
-  }
-
-  @ApiOperation({ summary: 'Delete a project' })
-  @ApiResponse({ status: 200, description: 'Project deleted successfully' })
-  @ApiResponse({ status: 404, description: 'Project not found' })
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.projectsService.remove(id);
-  }
-
   @Patch('reorder')
   @ApiOperation({ 
     summary: 'Reorder projects',
@@ -203,6 +187,22 @@ export class ProjectsController {
   })
   async reorderProjects(@Body() reorderData: { id: string; order: number }[]) {
     return this.projectsService.reorderProjects(reorderData);
+  }
+
+  @ApiOperation({ summary: 'Update a project' })
+  @ApiResponse({ status: 200, description: 'Project updated successfully' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateProjectDto: UpdateProjectDto) {
+    return this.projectsService.update(id, updateProjectDto);
+  }
+
+  @ApiOperation({ summary: 'Delete a project' })
+  @ApiResponse({ status: 200, description: 'Project deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.projectsService.remove(id);
   }
 
   @Patch(':id/order/:order')

--- a/src/upload/storage/gcs-storage.provider.spec.ts
+++ b/src/upload/storage/gcs-storage.provider.spec.ts
@@ -53,7 +53,6 @@ describe('GcsStorageProvider', () => {
     expect(save).toHaveBeenCalledWith(Buffer.from('image'), {
       contentType: 'image/webp',
       resumable: false,
-      predefinedAcl: 'publicRead',
     });
     expect(url).toBe('https://storage.googleapis.com/rakium-bucket/projects/demo/image.webp');
   });

--- a/src/upload/storage/gcs-storage.provider.ts
+++ b/src/upload/storage/gcs-storage.provider.ts
@@ -41,7 +41,6 @@ export class GcsStorageProvider implements StorageProvider {
       await file.save(input.body, {
         contentType: input.contentType,
         resumable: false,
-        predefinedAcl: input.acl === 'public-read' ? 'publicRead' : 'private',
       });
 
       return `https://storage.googleapis.com/${this.bucketName}/${input.key}`;

--- a/src/upload/upload.controller.spec.ts
+++ b/src/upload/upload.controller.spec.ts
@@ -1,0 +1,24 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../auth/public.decorator';
+import { UploadController } from './upload.controller';
+
+describe('UploadController auth metadata', () => {
+  it('protects the controller with JwtAuthGuard by default', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, UploadController);
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('does not expose write endpoints as public', () => {
+    expect(isPublic('testUpload')).toBeFalsy();
+    expect(isPublic('uploadFile')).toBeFalsy();
+    expect(isPublic('uploadImageWithVariants')).toBeFalsy();
+    expect(isPublic('uploadToProjectGallery')).toBeFalsy();
+    expect(isPublic('uploadImageWithVariants2')).toBeFalsy();
+  });
+
+  function isPublic(methodName: keyof UploadController) {
+    return Reflect.getMetadata(IS_PUBLIC_KEY, UploadController.prototype[methodName]);
+  }
+});

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -11,7 +11,6 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadService } from './upload.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { Public } from '../auth/public.decorator';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiConsumes, ApiBody, ApiParam } from '@nestjs/swagger';
 
 @ApiTags('upload')
@@ -22,10 +21,9 @@ export class UploadController {
   constructor(private readonly uploadService: UploadService) {}
 
   @Post('test')
-  @Public()
   @ApiOperation({ 
-    summary: 'Test de upload (público)',
-    description: 'Endpoint temporal público para probar el upload de imágenes'
+    summary: 'Test de upload',
+    description: 'Endpoint protegido para probar el upload de imágenes'
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -61,8 +59,8 @@ export class UploadController {
 
   @Post('file')
   @ApiOperation({
-    summary: 'Upload a file to Backblaze B2',
-    description: 'Uploads a file to Backblaze B2 storage with optional optimization. Supports images (JPEG, PNG, GIF, WebP) with automatic optimization enabled by default.'
+    summary: 'Upload a file to configured storage',
+    description: 'Uploads a file to the configured storage provider with optional optimization. Supports images (JPEG, PNG, GIF, WebP) with automatic optimization enabled by default.'
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -98,7 +96,7 @@ export class UploadController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Invalid file type, file too large, or Backblaze B2 not configured',
+    description: 'Invalid file type, file too large, or storage provider not configured',
   })
   @UseInterceptors(FileInterceptor('file'))
   async uploadFile(

--- a/src/videos/videos.controller.spec.ts
+++ b/src/videos/videos.controller.spec.ts
@@ -1,0 +1,29 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../auth/public.decorator';
+import { VideosController } from './videos.controller';
+
+describe('VideosController auth metadata', () => {
+  it('protects the controller with JwtAuthGuard by default', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, VideosController);
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('keeps published-video read routes public', () => {
+    expect(isPublic('findPublicVideos')).toBe(true);
+    expect(isPublic('findAll')).toBe(true);
+    expect(isPublic('findOne')).toBe(true);
+  });
+
+  it('keeps video write routes behind the controller guard', () => {
+    expect(isPublic('create')).toBeFalsy();
+    expect(isPublic('update')).toBeFalsy();
+    expect(isPublic('remove')).toBeFalsy();
+    expect(isPublic('reorder')).toBeFalsy();
+  });
+
+  function isPublic(methodName: keyof VideosController) {
+    return Reflect.getMetadata(IS_PUBLIC_KEY, VideosController.prototype[methodName]);
+  }
+});


### PR DESCRIPTION
## Summary
- Locks down `upload/test` so it requires bearer auth, updates smoke coverage, and aligns the Bruno collection.
- Adds auth metadata tests for auth, upload, gallery, video, and project route exposure.
- Makes the legacy public gallery route use the published-project service path.
- Reorders `PATCH /projects/reorder` before dynamic project patch routes.
- Adds `npm run dokploy:preflight` for DB counts, duplicate project order blockers, and storage env warnings before Dokploy cutover.
- Adds `npm run storage:rewrite-gcs-urls` as a dry-run-first manifest-based URL rewrite step for Backblaze -> GCS.
- Cleans old dump-import docs so they do not suggest modifying Dockerfile or embedding dumps into images.

## Validation
- `npm.cmd run build`
- `npm.cmd test -- --runInBand`
- `npm run smoke:api` locally against `http://localhost:3013/api`
- `npm run dokploy:preflight` against local Postgres
- `npm run storage:plan-gcs-migration` + `npm run storage:rewrite-gcs-urls` dry-run against local Postgres

## Production safety
- No server, Railway, Dokploy, DNS, or production environment change was performed.
- GCS URL rewrite is dry-run by default and only applies with `STORAGE_MIGRATION_APPLY=true`.
- Dokploy cutover still requires explicit server action approval before touching env vars, DB import, DNS, Railway, or Dokploy.