### PR TITLE
Add Resend password reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ JWT_EXPIRATION="7d"
 PORT=3000
 CORS_ORIGINS="http://localhost:4200,http://localhost:5173,http://localhost:3000"
 
+# Password reset emails (Resend)
+RESEND_API_KEY=""
+MAIL_FROM="Rakium <no-reply@rakium.dev>"
+PASSWORD_RESET_URL_BASE="https://landicandela.com/reset-password"
+PASSWORD_RESET_TTL_MINUTES="60"
+
 # Optional: storage uploads
 STORAGE_PROVIDER="backblaze"
 

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ CORS_ORIGINS="http://localhost:4200,http://localhost:5173,http://localhost:3000"
 # Password reset emails (Resend)
 RESEND_API_KEY=""
 MAIL_FROM="Rakium <no-reply@rakium.dev>"
-PASSWORD_RESET_URL_BASE="https://landicandela.com/reset-password"
+PASSWORD_RESET_URL_BASE="https://rakium.dev/reset-password"
 PASSWORD_RESET_TTL_MINUTES="60"
 
 # Optional: storage uploads

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "passport-local": "^1.0.0",
         "prisma": "^5.10.2",
         "reflect-metadata": "^0.1.13",
+        "resend": "^6.12.4",
         "rxjs": "^7.8.1",
         "sharp": "^0.34.2",
         "swagger-ui-express": "5.0.1"
@@ -8446,6 +8447,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
@@ -11518,6 +11525,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -14839,6 +14852,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15142,6 +15161,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -15789,6 +15829,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "passport-local": "^1.0.0",
     "prisma": "^5.10.2",
     "reflect-metadata": "^0.1.13",
+    "resend": "^6.12.4",
     "rxjs": "^7.8.1",
     "sharp": "^0.34.2",
     "swagger-ui-express": "5.0.1"

--- a/prisma/migrations/20260611150000_add_password_reset_tokens/migration.sql
+++ b/prisma/migrations/20260611150000_add_password_reset_tokens/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
+  "id" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "token_hash" TEXT NOT NULL,
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "used_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "password_reset_tokens_token_hash_key" ON "password_reset_tokens"("token_hash");
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_user_id_idx" ON "password_reset_tokens"("user_id");
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_expires_at_idx" ON "password_reset_tokens"("expires_at");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'password_reset_tokens_user_id_fkey') THEN
+    ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey"
+      FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,17 +8,32 @@ datasource db {
 }
 
 model User {
-  id           String    @id @default(uuid())
-  email        String    @unique
-  passwordHash String
-  role         UserRole
-  clientId     String?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  client       Client?   @relation(fields: [clientId], references: [id])
-  projects     Project[] @relation("CreatedBy")
+  id                  String               @id @default(uuid())
+  email               String               @unique
+  passwordHash        String
+  role                UserRole
+  clientId            String?
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+  client              Client?              @relation(fields: [clientId], references: [id])
+  projects            Project[]            @relation("CreatedBy")
+  passwordResetTokens PasswordResetToken[]
 
   @@map("User")
+}
+
+model PasswordResetToken {
+  id        String    @id @default(uuid())
+  userId    String    @map("user_id")
+  tokenHash String    @unique @map("token_hash")
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("password_reset_tokens")
 }
 
 model Client {

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -10,13 +10,18 @@ describe('AuthController auth metadata', () => {
     expect(guards).toContain(JwtAuthGuard);
   });
 
-  it('keeps login public and protects profile endpoints', () => {
+  it('keeps login and password reset public and protects profile endpoints', () => {
     expect(isPublic('login')).toBe(true);
+    expect(isPublic('forgotPassword')).toBe(true);
+    expect(isPublic('resetPassword')).toBe(true);
     expect(isPublic('getProfile')).toBeFalsy();
     expect(isPublic('testAuth')).toBeFalsy();
   });
 
   function isPublic(methodName: keyof AuthController) {
-    return Reflect.getMetadata(IS_PUBLIC_KEY, AuthController.prototype[methodName]);
+    return Reflect.getMetadata(
+      IS_PUBLIC_KEY,
+      AuthController.prototype[methodName],
+    );
   }
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,21 @@
-import { Controller, Post, Body, Get, Request, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { LoginDto } from '../dto/login.dto';
+import { ForgotPasswordDto } from '../dto/forgot-password.dto';
+import { ResetPasswordDto } from '../dto/reset-password.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { Public } from './public.decorator';
 
@@ -13,8 +27,8 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @ApiOperation({ summary: 'Login' })
-  @ApiResponse({ 
-    status: 200, 
+  @ApiResponse({
+    status: 200,
     description: 'Successful login',
     schema: {
       type: 'object',
@@ -26,10 +40,16 @@ export class AuthController {
         user: {
           type: 'object',
           properties: {
-            id: { type: 'string', example: '123e4567-e89b-12d3-a456-426614174000' },
+            id: {
+              type: 'string',
+              example: '123e4567-e89b-12d3-a456-426614174000',
+            },
             email: { type: 'string', example: 'admin@rakium.com' },
             role: { type: 'string', example: 'ADMIN' },
-            clientId: { type: 'string', example: '123e4567-e89b-12d3-a456-426614174000' },
+            clientId: {
+              type: 'string',
+              example: '123e4567-e89b-12d3-a456-426614174000',
+            },
           },
         },
       },
@@ -40,6 +60,26 @@ export class AuthController {
   @Public()
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto.email, loginDto.password);
+  }
+
+  @Post('forgot-password')
+  @Public()
+  @ApiOperation({ summary: 'Request password reset email' })
+  @ApiResponse({ status: 201, description: 'Password reset request accepted' })
+  async forgotPassword(@Body() forgotPasswordDto: ForgotPasswordDto) {
+    return this.authService.requestPasswordReset(forgotPasswordDto.email);
+  }
+
+  @Post('reset-password')
+  @Public()
+  @ApiOperation({ summary: 'Reset password using an email token' })
+  @ApiResponse({ status: 201, description: 'Password reset successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token' })
+  async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
+    return this.authService.resetPassword(
+      resetPasswordDto.token,
+      resetPasswordDto.password,
+    );
   }
 
   @Get('me')
@@ -58,7 +98,7 @@ export class AuthController {
     return {
       message: 'Authentication successful',
       user: req.user,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-} 
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -7,10 +7,12 @@ import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { UsersModule } from '../users/users.module';
 import { getRequiredEnv } from '../config/required-env';
+import { MailModule } from '../mail/mail.module';
 
 @Module({
   imports: [
     UsersModule,
+    MailModule,
     PassportModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
@@ -27,4 +29,4 @@ import { getRequiredEnv } from '../config/required-env';
   providers: [AuthService, JwtStrategy],
   exports: [AuthService],
 })
-export class AuthModule {} 
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,22 +1,34 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import { createHash, randomBytes } from 'crypto';
+import * as bcrypt from 'bcrypt';
 import { UsersService } from '../users/users.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { MailService } from '../mail/mail.service';
 
 @Injectable()
 export class AuthService {
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
+    private prisma: PrismaService,
+    private configService: ConfigService,
+    private mailService: MailService,
   ) {}
 
   async login(email: string, password: string) {
     try {
       const user = await this.usersService.validateUser(email, password);
-      const payload = { 
-        sub: user.id, 
+      const payload = {
+        sub: user.id,
         email: user.email,
         role: user.role,
-        clientId: user.clientId 
+        clientId: user.clientId,
       };
 
       return {
@@ -32,4 +44,105 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
   }
-} 
+
+  async requestPasswordReset(email: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true },
+    });
+
+    if (!user) {
+      return this.passwordResetRequestResponse();
+    }
+
+    await this.prisma.passwordResetToken.updateMany({
+      where: {
+        userId: user.id,
+        usedAt: null,
+      },
+      data: {
+        usedAt: new Date(),
+      },
+    });
+
+    const token = randomBytes(32).toString('base64url');
+    const tokenHash = this.hashPasswordResetToken(token);
+    const expiresAt = new Date(
+      Date.now() + this.getPasswordResetTtlMinutes() * 60 * 1000,
+    );
+
+    await this.prisma.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+      },
+    });
+
+    await this.mailService.sendPasswordResetEmail(
+      user.email,
+      this.buildPasswordResetUrl(token),
+    );
+
+    return this.passwordResetRequestResponse();
+  }
+
+  async resetPassword(token: string, password: string) {
+    const tokenHash = this.hashPasswordResetToken(token);
+    const resetToken = await this.prisma.passwordResetToken.findUnique({
+      where: { tokenHash },
+      include: { user: { select: { id: true } } },
+    });
+
+    if (
+      !resetToken ||
+      resetToken.usedAt ||
+      resetToken.expiresAt <= new Date()
+    ) {
+      throw new BadRequestException(
+        'El link de recuperación no es válido o venció',
+      );
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    await this.prisma.$transaction([
+      this.prisma.user.update({
+        where: { id: resetToken.user.id },
+        data: { passwordHash },
+      }),
+      this.prisma.passwordResetToken.update({
+        where: { id: resetToken.id },
+        data: { usedAt: new Date() },
+      }),
+    ]);
+
+    return { message: 'Contraseña actualizada correctamente' };
+  }
+
+  private hashPasswordResetToken(token: string) {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private buildPasswordResetUrl(token: string) {
+    const baseUrl =
+      this.configService.get<string>('PASSWORD_RESET_URL_BASE') ||
+      'https://landicandela.com/reset-password';
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    return `${baseUrl}${separator}token=${encodeURIComponent(token)}`;
+  }
+
+  private getPasswordResetTtlMinutes() {
+    const ttl = Number(
+      this.configService.get<string>('PASSWORD_RESET_TTL_MINUTES') || '60',
+    );
+    return Number.isFinite(ttl) && ttl > 0 ? ttl : 60;
+  }
+
+  private passwordResetRequestResponse() {
+    return {
+      message:
+        'Si el email existe, enviaremos instrucciones para recuperar la contraseña',
+    };
+  }
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -127,7 +127,7 @@ export class AuthService {
   private buildPasswordResetUrl(token: string) {
     const baseUrl =
       this.configService.get<string>('PASSWORD_RESET_URL_BASE') ||
-      'https://landicandela.com/reset-password';
+      'https://rakium.dev/reset-password';
     const separator = baseUrl.includes('?') ? '&' : '?';
     return `${baseUrl}${separator}token=${encodeURIComponent(token)}`;
   }

--- a/src/dto/forgot-password.dto.ts
+++ b/src/dto/forgot-password.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ForgotPasswordDto {
+  @ApiProperty({
+    description: 'Email del usuario que necesita recuperar acceso',
+    example: 'usuario@ejemplo.com',
+  })
+  @IsEmail()
+  email: string;
+}

--- a/src/dto/reset-password.dto.ts
+++ b/src/dto/reset-password.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    description: 'Token de recuperación recibido por email',
+  })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @ApiProperty({
+    description: 'Nueva contraseña',
+    minLength: 6,
+  })
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MailService } from './mail.service';
+
+@Module({
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailModule {}

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+
+@Injectable()
+export class MailService {
+  private readonly logger = new Logger(MailService.name);
+  private readonly resend?: Resend;
+  private readonly from: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('RESEND_API_KEY');
+    this.from =
+      this.configService.get<string>('MAIL_FROM') ||
+      'Rakium <no-reply@rakium.dev>';
+
+    if (apiKey) {
+      this.resend = new Resend(apiKey);
+    }
+  }
+
+  async sendPasswordResetEmail(to: string, resetUrl: string) {
+    if (!this.resend) {
+      this.logger.warn(
+        'RESEND_API_KEY is not configured; password reset email was not sent.',
+      );
+      return;
+    }
+
+    const { error } = await this.resend.emails.send({
+      from: this.from,
+      to,
+      subject: 'Recuperar contraseña',
+      html: this.buildPasswordResetHtml(resetUrl),
+      text: `Para recuperar tu contraseña, abrí este link: ${resetUrl}`,
+    });
+
+    if (error) {
+      this.logger.error(
+        `Resend failed to send password reset email: ${error.message}`,
+      );
+      throw new Error('Password reset email could not be sent');
+    }
+  }
+
+  private buildPasswordResetHtml(resetUrl: string) {
+    return `
+      <div style="font-family: Arial, sans-serif; color: #111827; line-height: 1.5;">
+        <h1 style="font-size: 20px;">Recuperar contraseña</h1>
+        <p>Recibimos una solicitud para cambiar tu contraseña.</p>
+        <p>
+          <a href="${resetUrl}" style="display: inline-block; padding: 12px 18px; background: #7c3aed; color: #ffffff; text-decoration: none; border-radius: 6px;">
+            Crear nueva contraseña
+          </a>
+        </p>
+        <p>Este link vence pronto y solo puede usarse una vez.</p>
+        <p>Si no pediste este cambio, podés ignorar este email.</p>
+      </div>
+    `;
+  }
+}

--- a/src/personal/personal.controller.ts
+++ b/src/personal/personal.controller.ts
@@ -70,6 +70,12 @@ export class PersonalController {
     return this.personalService.updateNote(req.user, id, dto);
   }
 
+  @Delete('notes/:id')
+  @ApiOperation({ summary: 'Archive a personal note' })
+  deleteNote(@Request() req, @Param('id') id: string) {
+    return this.personalService.deleteNote(req.user, id);
+  }
+
   @Get('finance')
   @ApiOperation({ summary: 'List accounts, categories and recent transactions' })
   listFinance(@Request() req) {

--- a/src/personal/personal.service.ts
+++ b/src/personal/personal.service.ts
@@ -250,6 +250,20 @@ export class PersonalService {
     });
   }
 
+  async deleteNote(user: AuthUser, id: string) {
+    const clientId = this.getClientId(user);
+    await this.ensureNoteBelongsToClient(id, clientId);
+
+    return this.prisma.personalNote.update({
+      where: { id },
+      data: {
+        archivedAt: new Date(),
+        pinned: false,
+      },
+      include: { area: true },
+    });
+  }
+
   async listFinance(user: AuthUser) {
     const clientId = this.getClientId(user);
     const [accounts, categories, transactions] = await Promise.all([


### PR DESCRIPTION
## Summary
- add Resend-backed forgot/reset password endpoints with one-time token storage
- add password reset token migration and email service configuration
- document required Resend/mail environment variables

## Test
- npm run build
- npm test -- --runInBand --watchman=false auth users